### PR TITLE
Attempt to fix homebrew auto-upgrading packages

### DIFF
--- a/tools/mac_1_get-dependencies
+++ b/tools/mac_1_get-dependencies
@@ -11,6 +11,12 @@ else
     sudo='sudo'
 fi
 
+# this is set to ensure that homebrew doesn't try and upgrade everything,
+# which can fail
+#
+# see: https://github.com/Homebrew/brew/issues/9285
+export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+
 echo "installing brew dependencies"
 brew install qt5
 


### PR DESCRIPTION
The line:

```bash
brew install qt5
```

Is causing the OSX build to fail, because `brew` "helpfully" upgrades any packages it things might've been affected by the installation.

This is, in general, "correct" behavior for brew to have, but it can cause problems in GitHub actions because the runners (VMs/containers) might have a very different brew configuration from what is up-to-date in the brew central repo.

This patch just attempts to disable `brew` from trying to hollistically upgrade everything, because the SCONE build only really depends on a very small number of external binaries (a compiler, Qt, CMake - that's basically it)